### PR TITLE
Move find_library call before generation

### DIFF
--- a/src/find_libpython/__init__.py
+++ b/src/find_libpython/__init__.py
@@ -228,13 +228,13 @@ def candidate_paths(suffix=SHLIB_SUFFIX):
 
     lib_basenames = list(candidate_names(suffix=suffix))
 
-    for directory in lib_dirs:
-        for basename in lib_basenames:
-            yield os.path.join(directory, basename)
-
     # In macOS and Windows, ctypes.util.find_library returns a full path:
     for basename in lib_basenames:
         yield ctypes.util.find_library(library_name(basename))
+
+    for directory in lib_dirs:
+        for basename in lib_basenames:
+            yield os.path.join(directory, basename)
 
 
 # Possibly useful links:


### PR DESCRIPTION
On Windows and MacOS `ctypes.find_library` will return the full path to
the library requested. This previously appeared after the automatic
generation of paths to check in candidate_paths. Since this should
always work, we put it first.

Closes #1.