### PR TITLE
Revert "Move find_library call before generation (#6)"

### DIFF
--- a/src/find_libpython/__init__.py
+++ b/src/find_libpython/__init__.py
@@ -228,13 +228,13 @@ def candidate_paths(suffix=SHLIB_SUFFIX):
 
     lib_basenames = list(candidate_names(suffix=suffix))
 
-    # In macOS and Windows, ctypes.util.find_library returns a full path:
-    for basename in lib_basenames:
-        yield ctypes.util.find_library(library_name(basename))
-
     for directory in lib_dirs:
         for basename in lib_basenames:
             yield os.path.join(directory, basename)
+
+    # In macOS and Windows, ctypes.util.find_library returns a full path:
+    for basename in lib_basenames:
+        yield ctypes.util.find_library(library_name(basename))
 
 
 # Possibly useful links:


### PR DESCRIPTION
This causes errors on Linux in Anaconda environments because
ctypes.util.find_library returns a random path rather than a library...

This reverts commit 775d316ecca808c19b0ee995d1de6b026f35609b.