### PR TITLE
Improve test

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -19,6 +19,11 @@ def tests(session):
     # install current module and runtime dependencies
     session.install('.')
 
+    # print info
+    session.run('python', '-m', 'find_libpython', '--candidate-names')
+    session.run('python', '-m', 'find_libpython', '--candidate-paths')
+    session.run('python', '-m', 'find_libpython', '-v')
+
     # install testing dependencies
     session.install(*test_reqs)
 

--- a/tests/test_find_libpython.py
+++ b/tests/test_find_libpython.py
@@ -1,5 +1,6 @@
 from find_libpython import find_libpython
 import ctypes
+import sys
 
 
 def test_find_libpython():
@@ -10,3 +11,8 @@ def test_find_libpython():
     # check to ensure it is a libpython share object
     lib = ctypes.CDLL(path)
     assert hasattr(lib, 'Py_Initialize')
+    # ensure it's the right version...
+    lib.Py_GetVersion.restype = ctypes.c_char_p
+    lib_version = lib.Py_GetVersion().decode().split()[0]
+    curr_version = sys.version.split()[0]
+    assert lib_version == curr_version


### PR DESCRIPTION
Ensure the version of libpython we load is the same as the version
associated with the python executable running the test.