### PR TITLE
Better Windows support

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
 
 Copyright 2018, Takafumi Arakaki
+Copyright Kaleb Barrett
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/src/find_libpython/__init__.py
+++ b/src/find_libpython/__init__.py
@@ -5,6 +5,7 @@ Locate libpython associated with this Python executable.
 # License
 #
 # Copyright 2018, Takafumi Arakaki
+# Copyright Kaleb Barrett
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/src/find_libpython/__init__.py
+++ b/src/find_libpython/__init__.py
@@ -37,10 +37,10 @@ from find_libpython._version import version as __version__  # noqa: F401
 
 logger = getLogger("find_libpython")
 
-is_windows = os.name == "nt"
 is_apple = sys.platform == "darwin"
 is_msys = sysconfig.get_platform().startswith("msys")
 is_mingw = sysconfig.get_platform().startswith("mingw")
+is_windows = os.name == "nt" and not is_mingw and not is_msys
 
 SHLIB_SUFFIX = sysconfig.get_config_var("SHLIB_SUFFIX")
 if SHLIB_SUFFIX is None:


### PR DESCRIPTION
On Windows, `sys.dllhandle` provides a consistent way to access python.dll. This should be sufficient to get find_libpython to work in python.org and Anaconda distributions on Windows. Also made `is_windows=False` when wither `is_msys` or `is_mingw` is `True`, since we intend to treat them differently.