### PR TITLE
Don't try library names that don't include the full version

### DIFF
--- a/src/find_libpython/__init__.py
+++ b/src/find_libpython/__init__.py
@@ -144,8 +144,6 @@ def candidate_names(suffix=_SHLIB_SUFFIX):
     for stem in [
         "python{VERSION}{ABIFLAGS}".format(**sysdata),
         "python{VERSION}".format(**sysdata),
-        "python{v.major}".format(**sysdata),
-        "python",
     ]:
         yield dlprefix + stem + suffix
 


### PR DESCRIPTION
To prevent accidentally finding the wrong version, as the homebrew job used to. Leaving a computed name with the version string and with/without the abiflags in case something is misconfigured.