### PR TITLE
Reintroduce testing linked libpython

### DIFF
--- a/src/find_libpython/__init__.py
+++ b/src/find_libpython/__init__.py
@@ -39,6 +39,7 @@ _is_apple = sys.platform == "darwin"
 _is_msys = sys.platform == "msys"
 _is_mingw = sys.platform == "mingw"
 _is_windows = os.name == "nt" and not _is_mingw and not _is_msys
+_is_posix = os.name == "posix"
 
 _SHLIB_SUFFIX = _get_config_var("_SHLIB_SUFFIX")
 if _SHLIB_SUFFIX is None:
@@ -300,6 +301,7 @@ def _finding_libpython():
     _logger.debug("_is_apple = %s", _is_apple)
     _logger.debug("_is_mingw = %s", _is_mingw)
     _logger.debug("_is_msys = %s", _is_msys)
+    _logger.debug("_is_posix = %s", _is_posix)
     for path in candidate_paths():
         _logger.debug("Candidate: %s", path)
         normalized = _normalize_path(path)


### PR DESCRIPTION
Reverts #15.

@filmor Looks like it's still returning the executable on Ubuntu... I would think `ctypes.pythonapi` would be the executable even if it's `--enable-shared` because why load another library?

I think I'll come back to this by doing trial loading of candidate library names with `ctypes.CDLL` and passing the handle of libraries that succeed loading to this function. And *not* test `ctypes.pythonapi`.

It also *almost* works in msys2. Msys2 assumes dl_info.fname field is a unicode buffer unlike Unix where that info is static. I still get an empty name back after accounting for that, it requires more testing.