### PR TITLE
Use INSTSONAME to find libraries with version suffix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,9 +160,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Testing Requirements
-        run: python3 -m pip install nox
+        run: python3.8 -m pip install nox
       - name: Run Tests
-        run: python3 -m nox -e tests
+        run: python3.8 -m nox -e tests
 
   rhel8-appstream-py39:
     name: rhel8-appstream-py39
@@ -175,9 +175,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Testing Requirements
-        run: python3 -m pip install nox
+        run: python3.9 -m pip install nox
       - name: Run Tests
-        run: python3 -m nox -e tests
+        run: python3.9 -m nox -e tests
 
   msys:
     name: ${{ matrix.msystem }}-system-python

--- a/src/find_libpython/__init__.py
+++ b/src/find_libpython/__init__.py
@@ -141,6 +141,18 @@ def candidate_names(suffix=_SHLIB_SUFFIX):
     name : str
         Candidate name libpython.
     """
+
+    # Quoting configure.ac in the cpython code base:
+    # "INSTSONAME is the name of the shared library that will be use to install
+    # on the system - some systems like version suffix, others don't.""
+    #
+    # A typical INSTSONAME is 'libpython3.8.so.1.0' on Linux, or
+    # 'Python.framework/Versions/3.9/Python' on MacOS. Due to the possible
+    # version suffix we have to find the suffix within the filename.
+    INSTSONAME = _get_config_var("INSTSONAME")
+    if INSTSONAME and suffix in INSTSONAME:
+        yield INSTSONAME
+
     LDLIBRARY = _get_config_var("LDLIBRARY")
     if LDLIBRARY and os.path.splitext(LDLIBRARY)[1] == suffix:
         yield LDLIBRARY


### PR DESCRIPTION
Previously, Python libraries with a version suffix (e.g. `.so.1.0`)
were not found. Fix that by using the config variable `INSTSONAME`,
which is meant to point to the full library name, including a version
suffix, if applied during build.

Fixes #35