### PR TITLE
Look up libpython from /proc/<pid>/maps file of running process

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,5 @@ select = [
 ]
 ignore = [
     "E501",  # Line too long
+    "PLR0912",  # Too many branches
 ]


### PR DESCRIPTION
The original find_libpython did not find our libpython. This looks up the current process and looks for a library continaing `libpython`